### PR TITLE
Remove "no-console" restriction from ESlint not to confuse students

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
   "rules": {
     "strict":0,
     "no-unused-vars": 0,
-    "no-console": 1,
+    "no-console": 0,
     "semi": ["error", "always"],
     "allowImportExportEverywhere": false,
     "comma-dangle": [1, { //when to use the last comma


### PR DESCRIPTION
Students where thinking that the ESLint warnings about "no-console" rule were actual errors, so it would be best to disable this rule for educational purposes.